### PR TITLE
Stop shipping wheels for 32-bit Linux and Windows.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,8 +101,6 @@ jobs:
         - os: linux
           arch: aarch64
         - os: linux
-          arch: i686
-        - os: linux
           arch: x86_64
         - os: macos
           arch: arm64
@@ -110,14 +108,11 @@ jobs:
           arch: x86_64
         - os: windows
           arch: AMD64
-        - os: windows
-          arch: x86
-        - os: windows
-          arch: ARM64
 
     runs-on:
       ${{
-        (matrix.os == 'linux' && 'ubuntu-24.04')
+        (matrix.os == 'linux' && matrix.arch == 'aarch64' && 'ubuntu-24.04-arm')
+        || (matrix.os == 'linux' && 'ubuntu-24.04')
         || (matrix.os == 'macos' && matrix.arch == 'arm64' && 'macos-15')
         || (matrix.os == 'macos' && matrix.arch == 'x86_64' && 'macos-15-intel')
         || (matrix.os == 'windows' && 'windows-2022')
@@ -128,12 +123,6 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: astral-sh/setup-uv@v7
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        if: matrix.os == 'linux'
-        with:
-          platforms: all
 
       - name: Build sdist
         if: matrix.os == 'linux' && matrix.arch == 'x86_64'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* Stop shipping wheels for 32-bit Linux and Windows.
+
+  `PR #18 <https://github.com/adamchainz/tprof/pull/18>`__.
+
 1.0.0 (2026-01-14)
 ------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ build = [
 build = { requires-python = ">=3.14" }
 
 [tool.cibuildwheel]
+archs = [ "auto64" ]
 build = [
   "cp314-*",
   "cp314t-*",


### PR DESCRIPTION
Copy of https://github.com/adamchainz/time-machine/pull/605 for this repo, with the same reasoning.