### PR TITLE
Add a callback for call times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /.tox
 /build/
 /dist/
+*.pyd
+.idea/

--- a/src/tprof/api.py
+++ b/src/tprof/api.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import sys
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from pkgutil import resolve_name
 from statistics import mean, stdev
 from types import CodeType
-from typing import Any, Callable
+from typing import Any
 
 from rich.console import Console
 from rich.table import Table
@@ -26,7 +26,8 @@ def tprof(
     *targets: Any,
     label: str | None = None,
     compare: bool = False,
-    call_times_callback: Callable[[str | None, dict[CodeType, list[int]]], None] | None = None
+    call_times_callback: Callable[[str | None, dict[CodeType, list[int]]], None]
+    | None = None,
 ) -> Generator[None]:
     """
     Profile time spent in target callables and print a report when done.

--- a/src/tprof/api.py
+++ b/src/tprof/api.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from pkgutil import resolve_name
 from statistics import mean, stdev
 from types import CodeType
-from typing import Any
+from typing import Any, Callable
 
 from rich.console import Console
 from rich.table import Table
@@ -26,6 +26,7 @@ def tprof(
     *targets: Any,
     label: str | None = None,
     compare: bool = False,
+    call_times_callback: Callable[[str | None, dict[CodeType, list[int]]], None] | None = None
 ) -> Generator[None]:
     """
     Profile time spent in target callables and print a report when done.
@@ -93,7 +94,10 @@ def tprof(
         sys.monitoring.free_tool_id(TOOL_ID)
 
         if not exc:
-            display_report(label=label, compare=compare)
+            if call_times_callback is None:
+                display_report(label=label, compare=compare)
+            else:
+                call_times_callback(label, call_times)
 
         code_to_name.clear()
         enter_times.clear()

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import time
 
 from tprof import tprof
@@ -5,11 +7,10 @@ from tprof.api import CodeType
 
 test_name = "test_callback"
 
-expected_ns = 1E6
-delay_sec = expected_ns / 1E9
+expected_ns = 1e6
+delay_sec = expected_ns / 1e9
 
 expected_function_names = ["sample_a", "sample_b"]
-
 
 
 def call_times_callback(label: str, call_times: CodeType):
@@ -18,7 +19,7 @@ def call_times_callback(label: str, call_times: CodeType):
     for code_type, times in call_times.items():
         assert len(times) == 1
         function_time = times[0]
-        assert function_time >= 1E6  # in nanoseconds (we slept for 1 ms)
+        assert function_time >= 1e6  # in nanoseconds (we slept for 1 ms)
         function_names.append(code_type.co_name)
     assert sorted(function_names) == sorted(expected_function_names)
 
@@ -27,14 +28,19 @@ def sample_a() -> int:
     time.sleep(delay_sec)
     return 42
 
+
 def sample_b() -> int:
     time.sleep(delay_sec)
     return 43
+
 
 def main() -> None:
     sample_a()
     sample_b()
 
+
 def test_callback():
-    with tprof(sample_a, sample_b, label=test_name, call_times_callback=call_times_callback):
+    with tprof(
+        sample_a, sample_b, label=test_name, call_times_callback=call_times_callback
+    ):
         main()

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,0 +1,40 @@
+import time
+
+from tprof import tprof
+from tprof.api import CodeType
+
+test_name = "test_callback"
+
+expected_ns = 1E6
+delay_sec = expected_ns / 1E9
+
+expected_function_names = ["sample_a", "sample_b"]
+
+
+
+def call_times_callback(label: str, call_times: CodeType):
+    assert label == test_name
+    function_names = []
+    for code_type, times in call_times.items():
+        assert len(times) == 1
+        function_time = times[0]
+        assert function_time >= 1E6  # in nanoseconds (we slept for 1 ms)
+        function_names.append(code_type.co_name)
+    assert sorted(function_names) == sorted(expected_function_names)
+
+
+def sample_a() -> int:
+    time.sleep(delay_sec)
+    return 42
+
+def sample_b() -> int:
+    time.sleep(delay_sec)
+    return 43
+
+def main() -> None:
+    sample_a()
+    sample_b()
+
+def test_callback():
+    with tprof(sample_a, sample_b, label=test_name, call_times_callback=call_times_callback):
+        main()

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,25 +1,28 @@
 # python
+from __future__ import annotations
+
 import time
-from typing import Optional
 from types import CodeType
 
 from tprof import tprof
 
 test_name = "test_callback"
 
-expected_ns = 1E6
-delay_sec = expected_ns / 1E9
+expected_ns = 1e6
+delay_sec = expected_ns / 1e9
 
 expected_function_names = ["sample_a", "sample_b"]
 
 
-def call_times_callback(label: Optional[str], call_times: dict[CodeType, list[int]]) -> None:
+def call_times_callback(
+    label: str | None, call_times: dict[CodeType, list[int]]
+) -> None:
     assert label == test_name
     function_names = []
     for code_type, times in call_times.items():
         assert len(times) == 1
         function_time = times[0]
-        assert function_time >= 1E6  # in nanoseconds (we slept for 1 ms)
+        assert function_time >= 1e6  # in nanoseconds (we slept for 1 ms)
         function_names.append(code_type.co_name)
     assert sorted(function_names) == sorted(expected_function_names)
 
@@ -40,5 +43,7 @@ def main() -> None:
 
 
 def test_callback() -> None:
-    with tprof(sample_a, sample_b, label=test_name, call_times_callback=call_times_callback):
+    with tprof(
+        sample_a, sample_b, label=test_name, call_times_callback=call_times_callback
+    ):
         main()

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -1,7 +1,9 @@
+# python
 import time
+from typing import Optional
+from types import CodeType
 
 from tprof import tprof
-from tprof.api import CodeType
 
 test_name = "test_callback"
 
@@ -11,8 +13,7 @@ delay_sec = expected_ns / 1E9
 expected_function_names = ["sample_a", "sample_b"]
 
 
-
-def call_times_callback(label: str, call_times: CodeType):
+def call_times_callback(label: Optional[str], call_times: dict[CodeType, list[int]]) -> None:
     assert label == test_name
     function_names = []
     for code_type, times in call_times.items():
@@ -27,14 +28,17 @@ def sample_a() -> int:
     time.sleep(delay_sec)
     return 42
 
+
 def sample_b() -> int:
     time.sleep(delay_sec)
     return 43
+
 
 def main() -> None:
     sample_a()
     sample_b()
 
-def test_callback():
+
+def test_callback() -> None:
     with tprof(sample_a, sample_b, label=test_name, call_times_callback=call_times_callback):
         main()


### PR DESCRIPTION
This is an addition of a callback for the call times. An additional test case is also included.

The usage model is in testing, to get performance information on specific function(s) in a larger stack. The callback could check that performance is within expected bounds. It could also write the performance data to a local SQLite DB for later validation.