### PR TITLE
Report the median rather than the mean

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Changelog
 
   `PR #47 <https://github.com/adamchainz/tprof/pull/47>`__.
 
+* Report the median rather than the mean, since it is more robust to outliers.
+  Comparison mode deltas are now computed from medians too.
+
+  `PR #48 <https://github.com/adamchainz/tprof/pull/48>`__.
+
 * Build with frame pointers enabled, preparation for `PEP 831 <https://peps.python.org/pep-0831/>`__.
 
   `PR #40 <https://github.com/adamchainz/tprof/issues/40>`__.

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ When using ``-m`` with a module, you can skip the ``<module>`` part and it will 
     $ tprof -t lib:maths ./example.py
     ...
     🎯 tprof results:
-     function    calls total  mean ± σ     min … max
+     function    calls total  median ± σ     min … max
      lib:maths()     2 610ms 305ms ± 2ms 304ms … 307ms
 
 Full help:
@@ -141,7 +141,7 @@ For example, given this code:
 
     $ tprof -x -t before -t after -m example
     🎯 tprof results:
-     function         calls total  mean ± σ      min … max   delta
+     function         calls total  median ± σ      min … max   delta
      example:before()   100 227ms   2ms ± 34μs   2ms … 2ms   -
      example:after()    100  86ms 856μs ± 15μs 835μs … 910μs -62.27%
 
@@ -183,7 +183,7 @@ For example, given this code:
     $ python example.py
     Doing the maths…
     🎯 tprof results:
-     function    calls total  mean ± σ   min … max
+     function    calls total  median ± σ   min … max
      lib:maths()     1 305ms 305ms     305ms … 305ms
     The maths has been done!
 
@@ -216,7 +216,7 @@ Another example using comparison mode:
 
     $ python example.py
     🎯 tprof results:
-     function          calls total  mean ± σ      min … max delta
+     function          calls total  median ± σ      min … max delta
      __main__:before()   100 227ms   2ms ± 83μs   2ms … 3ms -
      __main__:after()    100  85ms 853μs ± 22μs 835μs … 1ms -62.35%
 

--- a/src/tprof/api.py
+++ b/src/tprof/api.py
@@ -117,7 +117,7 @@ def display_report(label: str | None = None, compare: bool = False) -> None:
     table.add_column("function")
     table.add_column("calls", justify="right")
     table.add_column("total", justify="right")
-    table.add_column("mean", header_style="bright_green", justify="right")
+    table.add_column("median", header_style="bright_green", justify="right")
     table.add_column("±", justify="right")
     table.add_column("σ", header_style="bright_green", justify="left")
     table.add_column("min", header_style="cyan", justify="right")
@@ -129,7 +129,7 @@ def display_report(label: str | None = None, compare: bool = False) -> None:
     baseline: float | None = None
     first = True
 
-    for name, (count, total, min_ns, max_ns, mean_ns, stdev_ns) in zip(
+    for name, (count, total, min_ns, max_ns, median_ns, stdev_ns) in zip(
         code_to_name.values(), record.stats(), strict=True
     ):
         if not compare:
@@ -138,12 +138,12 @@ def display_report(label: str | None = None, compare: bool = False) -> None:
             if first:
                 delta = ("[dim]-[/dim]",)
                 if count:
-                    baseline = mean_ns
+                    baseline = median_ns
             else:
                 if not baseline:
                     delta = ("[dim]n/a[/dim]",)
                 else:
-                    percent_diff = ((mean_ns - baseline) / baseline) * 100
+                    percent_diff = ((median_ns - baseline) / baseline) * 100
                     colour = (
                         "bold bright_green" if percent_diff <= 0 else "bold bright_red"
                     )
@@ -154,7 +154,11 @@ def display_report(label: str | None = None, compare: bool = False) -> None:
             f"[bold]{name}()[/bold]",
             str(count),
             _format_time(total, None),
-            (_format_time(int(mean_ns), "bright_green") if count else "[dim]n/a[/dim]"),
+            (
+                _format_time(int(median_ns), "bright_green")
+                if count
+                else "[dim]n/a[/dim]"
+            ),
             "±" if count > 1 else "",
             _format_time(int(stdev_ns), "bright_green") if count > 1 else "",
             _format_time(min_ns, "cyan") if count else "[dim]n/a[/dim]",

--- a/src/tprof/record.c
+++ b/src/tprof/record.c
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 /*
  * Recorded times are stored in C data structures rather than Python objects,
@@ -24,7 +25,7 @@
  * - On Python 3.13+, timestamps come from PyTime_PerfCounterRaw(), avoiding
  *   a Python-level call to time.perf_counter_ns() and int boxing/unboxing.
  *
- * stats() computes the reported statistics directly over the raw buffers,
+ * stats() computes the reported statistics directly over the raw values,
  * so recorded times never need converting to Python ints at all - only the
  * six aggregate values per target cross into Python.
  *
@@ -352,6 +353,41 @@ record_configure(PyObject *module, PyObject *arg)
     Py_RETURN_NONE;
 }
 
+/* Partially sort values so values[k] holds the k'th smallest value, with all
+   smaller values before it, using quickselect with Hoare partitioning. */
+static int64_t
+select_kth(int64_t *values, Py_ssize_t length, Py_ssize_t k)
+{
+    Py_ssize_t low = 0;
+    Py_ssize_t high = length - 1;
+    while (low < high) {
+        int64_t pivot = values[low + (high - low) / 2];
+        Py_ssize_t i = low - 1;
+        Py_ssize_t j = high + 1;
+        for (;;) {
+            do {
+                i++;
+            } while (values[i] < pivot);
+            do {
+                j--;
+            } while (values[j] > pivot);
+            if (i >= j) {
+                break;
+            }
+            int64_t swapped = values[i];
+            values[i] = values[j];
+            values[j] = swapped;
+        }
+        if (k <= j) {
+            high = j;
+        }
+        else {
+            low = j + 1;
+        }
+    }
+    return values[k];
+}
+
 static PyObject *
 record_stats(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
@@ -370,52 +406,90 @@ record_stats(PyObject *module, PyObject *Py_UNUSED(ignored))
 
     for (Py_ssize_t i = 0; i < state->num_targets; i++) {
         Py_ssize_t count = 0;
-        int64_t total = 0;
-        int64_t minimum = 0;
-        int64_t maximum = 0;
         for (ThreadData *data = threads; data != NULL; data = data->next) {
-            if (data->generation != state->generation) {
-                continue;
-            }
-            I64Array *durations = &data->durations[i];
-            for (Py_ssize_t j = 0; j < durations->len; j++) {
-                int64_t value = durations->items[j];
-                if (count == 0 || value < minimum) {
-                    minimum = value;
-                }
-                if (count == 0 || value > maximum) {
-                    maximum = value;
-                }
-                total += value;
-                count++;
+            if (data->generation == state->generation) {
+                count += data->durations[i].len;
             }
         }
 
-        double mean = count > 0 ? (double)total / (double)count : 0.0;
-
-        /* Sample standard deviation, matching statistics.stdev(). */
-        double stdev = 0.0;
-        if (count > 1) {
-            double squared_deviations = 0.0;
+        /* Gather this target's durations from the per-thread buffers into
+           one scratch buffer, for the median's quickselect. */
+        int64_t *values = NULL;
+        if (count > 0) {
+            values = PyMem_RawMalloc((size_t)count * sizeof(int64_t));
+            if (values == NULL) {
+                Py_DECREF(result);
+                return PyErr_NoMemory();
+            }
+            Py_ssize_t position = 0;
             for (ThreadData *data = threads; data != NULL; data = data->next) {
                 if (data->generation != state->generation) {
                     continue;
                 }
                 I64Array *durations = &data->durations[i];
-                for (Py_ssize_t j = 0; j < durations->len; j++) {
-                    double deviation = (double)durations->items[j] - mean;
-                    squared_deviations += deviation * deviation;
+                if (durations->len > 0) {
+                    memcpy(&values[position],
+                        durations->items,
+                        (size_t)durations->len * sizeof(int64_t));
+                    position += durations->len;
                 }
+            }
+        }
+
+        int64_t total = 0;
+        int64_t minimum = 0;
+        int64_t maximum = 0;
+        for (Py_ssize_t j = 0; j < count; j++) {
+            int64_t value = values[j];
+            if (j == 0 || value < minimum) {
+                minimum = value;
+            }
+            if (j == 0 || value > maximum) {
+                maximum = value;
+            }
+            total += value;
+        }
+
+        /* Sample standard deviation, matching statistics.stdev(). */
+        double stdev = 0.0;
+        if (count > 1) {
+            double mean = (double)total / (double)count;
+            double squared_deviations = 0.0;
+            for (Py_ssize_t j = 0; j < count; j++) {
+                double deviation = (double)values[j] - mean;
+                squared_deviations += deviation * deviation;
             }
             stdev = sqrt(squared_deviations / (double)(count - 1));
         }
+
+        /* Median, matching statistics.median(): for an even count, the
+           midpoint of the two middle values. Computed last since quickselect
+           reorders the scratch buffer. */
+        double median = 0.0;
+        if (count > 0) {
+            int64_t upper = select_kth(values, count, count / 2);
+            if (count % 2) {
+                median = (double)upper;
+            }
+            else {
+                int64_t lower = values[0];
+                for (Py_ssize_t j = 1; j < count / 2; j++) {
+                    if (values[j] > lower) {
+                        lower = values[j];
+                    }
+                }
+                median = ((double)lower + (double)upper) / 2.0;
+            }
+        }
+
+        PyMem_RawFree(values);
 
         PyObject *item = Py_BuildValue("nLLLdd",
             count,
             (long long)total,
             (long long)minimum,
             (long long)maximum,
-            mean,
+            median,
             stdev);
         if (item == NULL) {
             Py_DECREF(result);


### PR DESCRIPTION
The median is more robust to the outliers that profiling data usually contains, such as garbage collection pauses and cold caches, so use it for the headline statistic and for comparison mode deltas.

The median is computed exactly in C at report time, by gathering each target's durations into a scratch buffer and running quickselect, so there is no change to recording overhead.