### PR TITLE
Return per-function data from `tprof()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Changelog
 
   `PR #48 <https://github.com/adamchainz/tprof/pull/48>`__.
 
+* ``tprof()`` now yields a list of ``FunctionStats`` objects, populated when the profiled block ends, for programmatic access to the results.
+
+  `PR #52 <https://github.com/adamchainz/tprof/pull/52>`__.
+
 * Build with frame pointers enabled, preparation for `PEP 831 <https://peps.python.org/pep-0831/>`__.
 
   `PR #40 <https://github.com/adamchainz/tprof/issues/40>`__.

--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,9 @@ __ https://docs.python.org/3.14/library/pkgutil.html#pkgutil.resolve_name
 
 Set ``compare`` to ``True`` to enable comparison mode, as documented above in the CLI section.
 
+The context manager yields a list of ``FunctionStats``, populated with one entry per target when the profiled block ends, for programmatic access to the results.
+Each ``FunctionStats`` has these attributes: ``name``, ``calls``, ``total_ns``, ``min_ns``, ``max_ns``, ``median_ns``, and ``stdev_ns``.
+
 For example, given this code:
 
 .. code-block:: python
@@ -219,6 +222,21 @@ Another example using comparison mode:
      function          calls total  median ± σ      min … max delta
      __main__:before()   100 227ms   2ms ± 83μs   2ms … 3ms -
      __main__:after()    100  85ms 853μs ± 22μs 835μs … 1ms -62.35%
+
+Use the yielded list to access the results programmatically.
+It contains one ``FunctionStats`` per target, in the same order as passed to ``tprof()``, so with a single target you can unpack it directly:
+
+.. code-block:: python
+
+    from lib import maths
+
+    from tprof import tprof
+
+    with tprof(maths) as results:
+        maths()
+
+    (function_stats,) = results  # unpack the single result for maths()
+    print(f"{function_stats.name} took {function_stats.median_ns}ns")
 
 History
 -------

--- a/src/tprof/api.py
+++ b/src/tprof/api.py
@@ -18,12 +18,42 @@ console = Console(stderr=True)
 code_to_name: dict[CodeType, str] = {}
 
 
+class FunctionStats:
+    __slots__ = (
+        "name",
+        "calls",
+        "total_ns",
+        "min_ns",
+        "max_ns",
+        "median_ns",
+        "stdev_ns",
+    )
+
+    def __init__(
+        self,
+        name: str,
+        calls: int,
+        total_ns: int,
+        min_ns: int,
+        max_ns: int,
+        median_ns: float,
+        stdev_ns: float,
+    ) -> None:
+        self.name = name
+        self.calls = calls
+        self.total_ns = total_ns
+        self.min_ns = min_ns
+        self.max_ns = max_ns
+        self.median_ns = median_ns
+        self.stdev_ns = stdev_ns
+
+
 @contextmanager
 def tprof(
     *targets: Any,
     label: str | None = None,
     compare: bool = False,
-) -> Generator[None]:
+) -> Generator[list[FunctionStats]]:
     """
     Profile time spent in target callables and print a report when done.
     """
@@ -83,9 +113,10 @@ def tprof(
     # sys.monitoring.DISABLE during any previous profiling session.
     sys.monitoring.restart_events()
 
+    results: list[FunctionStats] = []
     exc = False
     try:
-        yield
+        yield results
     except Exception:
         exc = True
         raise
@@ -96,16 +127,23 @@ def tprof(
         sys.monitoring.register_callback(TOOL_ID, sys.monitoring.events.PY_UNWIND, None)
         sys.monitoring.free_tool_id(TOOL_ID)
 
+        results[:] = [
+            FunctionStats(name, count, total, min_ns, max_ns, median_ns, stdev_ns)
+            for name, (count, total, min_ns, max_ns, median_ns, stdev_ns) in zip(
+                code_to_name.values(), record.stats(), strict=True
+            )
+        ]
+
         if not exc:
-            display_report(label=label, compare=compare)
+            display_report(results, label=label, compare=compare)
 
         code_to_name.clear()
         record.configure(())
 
 
-def display_report(label: str | None = None, compare: bool = False) -> None:
-    from tprof import record
-
+def display_report(
+    results: list[FunctionStats], label: str | None = None, compare: bool = False
+) -> None:
     heading = "[bold red]🎯 tprof[/bold red] results"
     if label:
         heading += f" @ [bold bright_blue]{label}[/bold bright_blue]"
@@ -129,9 +167,11 @@ def display_report(label: str | None = None, compare: bool = False) -> None:
     baseline: float | None = None
     first = True
 
-    for name, (count, total, min_ns, max_ns, median_ns, stdev_ns) in zip(
-        code_to_name.values(), record.stats(), strict=True
-    ):
+    for function_stats in results:
+        name = function_stats.name
+        count = function_stats.calls
+        median_ns = function_stats.median_ns
+
         if not compare:
             delta: tuple[str, ...] = ()
         else:
@@ -153,17 +193,23 @@ def display_report(label: str | None = None, compare: bool = False) -> None:
         table.add_row(
             f"[bold]{name}()[/bold]",
             str(count),
-            _format_time(total, None),
+            _format_time(function_stats.total_ns, None),
             (
                 _format_time(int(median_ns), "bright_green")
                 if count
                 else "[dim]n/a[/dim]"
             ),
             "±" if count > 1 else "",
-            _format_time(int(stdev_ns), "bright_green") if count > 1 else "",
-            _format_time(min_ns, "cyan") if count else "[dim]n/a[/dim]",
+            (
+                _format_time(int(function_stats.stdev_ns), "bright_green")
+                if count > 1
+                else ""
+            ),
+            _format_time(function_stats.min_ns, "cyan") if count else "[dim]n/a[/dim]",
             "…",
-            _format_time(max_ns, "magenta") if count else "[dim]n/a[/dim]",
+            _format_time(function_stats.max_ns, "magenta")
+            if count
+            else "[dim]n/a[/dim]",
             *delta,
         )
     console.print(table)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -219,6 +219,25 @@ class TestTprof:
         )
         assert errlines[3].rstrip().endswith(" n/a")
 
+    def test_results(self, capsys):
+        def sample() -> int:
+            return 42
+
+        with tprof(sample) as results:
+            sample()
+            sample()
+
+        (function_stats,) = results
+        assert function_stats.name == (
+            "tests.test_api:TestTprof.test_results.<locals>.sample"
+        )
+        assert function_stats.calls == 2
+        assert (
+            function_stats.min_ns <= function_stats.median_ns <= function_stats.max_ns
+        )
+        assert function_stats.total_ns >= function_stats.max_ns
+        assert function_stats.stdev_ns >= 0.0
+
     def test_threaded(self, capsys):
         def worker() -> None:
             time.sleep(0.01)


### PR DESCRIPTION
An alternative to #22: return a list of `FunctionStats` objects from `tprof()`, populated when the profiled block ends, for programmatic access to the results.