### PR TITLE
Add JSON output and baseline file comparison

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,18 @@ Changelog
 
   `PR #52 <https://github.com/adamchainz/tprof/pull/52>`__.
 
+* Add two options useful for comparing data between runs, such as when switching Git branches:
+
+  * `--json <path>` (`json_path` in the API) writes the statistics to a file
+    as JSON, or to stdout with '-'.
+
+  * `--baseline <path>` (`baseline_path` in the API) reads a previous run's
+    `--json` output and shows a delta column comparing each function's
+    median against that run. Mutually exclusive with `-x` (`--compare`), which
+    compares between targets within one run.
+
+  `PR #53 <https://github.com/adamchainz/tprof/pull/53>`__.
+
 * Build with frame pointers enabled, preparation for `PEP 831 <https://peps.python.org/pep-0831/>`__.
 
   `PR #40 <https://github.com/adamchainz/tprof/issues/40>`__.

--- a/README.rst
+++ b/README.rst
@@ -78,12 +78,14 @@ Full help:
 
 .. [[[cog
 .. import cog
+.. import os
 .. import subprocess
 .. import sys
 .. result = subprocess.run(
 ..     [sys.executable, "-m", "tprof", "--help"],
 ..     capture_output=True,
 ..     text=True,
+..     env={**os.environ, "COLUMNS": "80"},
 .. )
 .. cog.outl("")
 .. cog.outl(".. code-block:: console")
@@ -98,17 +100,21 @@ Full help:
 
 .. code-block:: console
 
-   usage: tprof [-h] -t target [-x] (-m module | script) ...
+   usage: tprof [-h] -t target [-x | --baseline path] [--json path]
+                (-m module | script) ...
 
    positional arguments:
-     script         Python script to run
-     args           Arguments to pass to the script or module
+     script           Python script to run
+     args             Arguments to pass to the script or module
 
    options:
-     -h, --help     show this help message and exit
-     -t target      Target callable to profile (format: module:function).
-     -x, --compare  Compare performance of targets, with the first as baseline.
-     -m module      Run library module as a script (like python -m)
+     -h, --help       show this help message and exit
+     -t target        Target callable to profile (format: module:function).
+     -x, --compare    Compare performance of targets, with the first as baseline.
+     --baseline path  Compare against statistics from a previous run's --json
+                      file.
+     --json path      Write statistics as JSON to this file, or '-' for stdout.
+     -m module        Run library module as a script (like python -m)
 
 .. [[[end]]]
 
@@ -145,11 +151,51 @@ For example, given this code:
      example:before()   100 227ms   2ms ± 34μs   2ms … 2ms   -
      example:after()    100  86ms 856μs ± 15μs 835μs … 910μs -62.27%
 
+JSON output
+^^^^^^^^^^^
+
+Pass ``--json <path>`` to also write the statistics to the given file as JSON, or ``-`` to write them to standard output.
+The file contains a ``functions`` list with the name, call count, and total, minimum, maximum, median, and standard deviation of times, in nanoseconds, per target:
+
+.. code-block:: json
+
+    {
+      "version": 1,
+      "label": null,
+      "functions": [
+        {
+          "name": "lib:maths",
+          "calls": 2,
+          "total_ns": 610622917,
+          "min_ns": 304285875,
+          "max_ns": 306337042,
+          "median_ns": 305311458.5,
+          "stdev_ns": 1450393.5
+        }
+      ]
+    }
+
+Baseline comparison mode
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Pass ``--baseline <path>`` with the ``--json`` output of a previous run to compare against that run, in an extra “delta” column that compares each function’s median against its median in the baseline run.
+Use this to check the effect of a change to the profiled code:
+
+.. code-block:: console
+
+    $ tprof -t lib:maths --json before.json ./example.py
+    ...
+    $ tprof -t lib:maths --baseline before.json ./example.py
+    ...
+    🎯 tprof results:
+     function    calls total  median ± σ     min … max     delta
+     lib:maths()     2 592ms 296ms ± 2ms  294ms … 297ms -3.11%
+
 API
 ---
 
-``tprof(*targets, label: str | None = None, compare: bool = False)``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``tprof(*targets, label=None, compare=False, json_path=None, baseline_path=None)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use this context manager / decorator within your code to perform profiling in a specific block.
 The report is printed when the block ends, each time it ends.
@@ -162,6 +208,11 @@ __ https://docs.python.org/3.14/library/pkgutil.html#pkgutil.resolve_name
 ``label`` is an optional string to add to the report heading to distinguish multiple reports.
 
 Set ``compare`` to ``True`` to enable comparison mode, as documented above in the CLI section.
+
+Set ``json_path`` to a file path to also write the statistics as JSON, as documented above in the CLI section, or ``-`` for standard output.
+
+Set ``baseline_path`` to the path of a previous run’s JSON statistics to enable baseline comparison mode, as documented above in the CLI section.
+It cannot be combined with ``compare``.
 
 The context manager yields a list of ``FunctionStats``, populated with one entry per target when the profiled block ends, for programmatic access to the results.
 Each ``FunctionStats`` has these attributes: ``name``, ``calls``, ``total_ns``, ``min_ns``, ``max_ns``, ``median_ns``, and ``stdev_ns``.

--- a/src/tprof/api.py
+++ b/src/tprof/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -53,6 +54,8 @@ def tprof(
     *targets: Any,
     label: str | None = None,
     compare: bool = False,
+    json_path: str | None = None,
+    baseline_path: str | None = None,
 ) -> Generator[list[FunctionStats]]:
     """
     Profile time spent in target callables and print a report when done.
@@ -62,6 +65,12 @@ def tprof(
 
     if not targets:
         raise ValueError("At least one target callable must be provided.")
+    if compare and baseline_path is not None:
+        raise ValueError("compare and baseline_path may not be combined.")
+
+    baseline = None
+    if baseline_path is not None:
+        baseline = _load_baseline(baseline_path)
 
     names: dict[CodeType, str] = {}
     for target in targets:
@@ -135,14 +144,56 @@ def tprof(
         ]
 
         if not exc:
-            display_report(results, label=label, compare=compare)
+            if json_path is not None:
+                _write_json(json_path, label, results)
+            display_report(results, label=label, compare=compare, baseline=baseline)
 
         code_to_name.clear()
         record.configure(())
 
 
+def _load_baseline(path: str) -> dict[str, float]:
+    try:
+        with open(path) as fp:
+            data = json.load(fp)
+        return {
+            function["name"]: function["median_ns"] for function in data["functions"]
+        }
+    except (OSError, ValueError, TypeError, KeyError) as exc:
+        raise ValueError(f"Cannot load baseline from {path!r}: {exc}") from exc
+
+
+def _write_json(path: str, label: str | None, results: list[FunctionStats]) -> None:
+    data = {
+        "version": 1,
+        "label": label,
+        "functions": [
+            {
+                "name": function_stats.name,
+                "calls": function_stats.calls,
+                "total_ns": function_stats.total_ns,
+                "min_ns": function_stats.min_ns,
+                "max_ns": function_stats.max_ns,
+                "median_ns": function_stats.median_ns,
+                "stdev_ns": function_stats.stdev_ns,
+            }
+            for function_stats in results
+        ],
+    }
+    if path == "-":
+        json.dump(data, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        with open(path, "w") as fp:
+            json.dump(data, fp, indent=2)
+            fp.write("\n")
+
+
 def display_report(
-    results: list[FunctionStats], label: str | None = None, compare: bool = False
+    results: list[FunctionStats],
+    label: str | None = None,
+    compare: bool = False,
+    baseline: dict[str, float] | None = None,
 ) -> None:
     heading = "[bold red]🎯 tprof[/bold red] results"
     if label:
@@ -161,37 +212,37 @@ def display_report(
     table.add_column("min", header_style="cyan", justify="right")
     table.add_column("…", justify="right")
     table.add_column("max", header_style="magenta", justify="left")
-    if compare:
+    if compare or baseline is not None:
         table.add_column("delta")
 
-    baseline: float | None = None
+    compare_baseline: float | None = None
     first = True
 
     for function_stats in results:
-        name = function_stats.name
         count = function_stats.calls
         median_ns = function_stats.median_ns
 
-        if not compare:
-            delta: tuple[str, ...] = ()
-        else:
+        delta: tuple[str, ...] = ()
+        if compare:
             if first:
                 delta = ("[dim]-[/dim]",)
                 if count:
-                    baseline = median_ns
+                    compare_baseline = median_ns
             else:
-                if not baseline:
+                if not compare_baseline:
                     delta = ("[dim]n/a[/dim]",)
                 else:
-                    percent_diff = ((median_ns - baseline) / baseline) * 100
-                    colour = (
-                        "bold bright_green" if percent_diff <= 0 else "bold bright_red"
-                    )
-                    delta = (f"[{colour}]{percent_diff:+.2f}%[/{colour}]",)
+                    delta = (_format_delta(median_ns, compare_baseline),)
+        elif baseline is not None:
+            baseline_median = baseline.get(function_stats.name)
+            if count and baseline_median:
+                delta = (_format_delta(median_ns, baseline_median),)
+            else:
+                delta = ("[dim]n/a[/dim]",)
 
         first = False
         table.add_row(
-            f"[bold]{name}()[/bold]",
+            f"[bold]{function_stats.name}()[/bold]",
             str(count),
             _format_time(function_stats.total_ns, None),
             (
@@ -213,6 +264,12 @@ def display_report(
             *delta,
         )
     console.print(table)
+
+
+def _format_delta(median_ns: float, baseline_ns: float) -> str:
+    percent_diff = ((median_ns - baseline_ns) / baseline_ns) * 100
+    colour = "bold bright_green" if percent_diff <= 0 else "bold bright_red"
+    return f"[{colour}]{percent_diff:+.2f}%[/{colour}]"
 
 
 def _format_time(ns: int, colour: str | None) -> str:

--- a/src/tprof/main.py
+++ b/src/tprof/main.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 from collections.abc import Sequence
 
-from tprof.api import tprof
+from tprof.api import _load_baseline, tprof
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -21,11 +21,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         required=True,
         help="Target callable to profile (format: module:function).",
     )
-    parser.add_argument(
+    delta_group = parser.add_mutually_exclusive_group()
+    delta_group.add_argument(
         "-x",
         "--compare",
         action="store_true",
         help="Compare performance of targets, with the first as baseline.",
+    )
+    delta_group.add_argument(
+        "--baseline",
+        dest="baseline_path",
+        metavar="path",
+        help="Compare against statistics from a previous run's --json file.",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_path",
+        metavar="path",
+        help="Write statistics as JSON to this file, or '-' for stdout.",
     )
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
@@ -59,7 +72,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             for target in targets
         ]
 
-    with tprof(*targets, compare=args.compare):
+    if args.baseline_path is not None:
+        try:
+            _load_baseline(args.baseline_path)
+        except ValueError as exc:
+            print(f"tprof: {exc}", file=sys.stderr)
+            return 2
+
+    with tprof(
+        *targets,
+        compare=args.compare,
+        json_path=args.json_path,
+        baseline_path=args.baseline_path,
+    ):
         orig_sys_argv = sys.argv
         sys.argv = [args.module, *args.args]
         try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import NoReturn
@@ -16,6 +17,18 @@ class TestTprof:
             pass  # pragma: no cover
 
         assert str(excinfo.value) == "At least one target callable must be provided."
+
+    def test_compare_and_baseline_path(self):
+        def sample() -> int:
+            return 42  # pragma: no cover
+
+        with (
+            pytest.raises(ValueError) as excinfo,
+            tprof(sample, compare=True, baseline_path="tprof.json"),
+        ):
+            pass  # pragma: no cover
+
+        assert str(excinfo.value) == "compare and baseline_path may not be combined."
 
     def test_target_not_callable(self):
         thing = 1
@@ -237,6 +250,97 @@ class TestTprof:
         )
         assert function_stats.total_ns >= function_stats.max_ns
         assert function_stats.stdev_ns >= 0.0
+
+    def test_json_path(self, capsys, tmp_path):
+        def sample() -> int:
+            return 42
+
+        path = tmp_path / "tprof.json"
+
+        with tprof(sample, label="run one", json_path=str(path)):
+            sample()
+
+        data = json.loads(path.read_text())
+        assert data["version"] == 1
+        assert data["label"] == "run one"
+        (function_data,) = data["functions"]
+        assert function_data["name"] == (
+            "tests.test_api:TestTprof.test_json_path.<locals>.sample"
+        )
+        assert function_data["calls"] == 1
+        assert function_data["min_ns"] <= function_data["max_ns"]
+
+    def test_json_path_stdout(self, capsys):
+        def sample() -> int:
+            return 42
+
+        with tprof(sample, json_path="-"):
+            sample()
+
+        out, err = capsys.readouterr()
+        data = json.loads(out)
+        assert data["version"] == 1
+        assert data["label"] is None
+        assert len(data["functions"]) == 1
+
+    def test_baseline(self, capsys, tmp_path):
+        def sample() -> int:
+            return 42
+
+        path = tmp_path / "tprof.json"
+
+        with tprof(sample, json_path=str(path)):
+            sample()
+        with tprof(sample, baseline_path=str(path)):
+            sample()
+
+        out, err = capsys.readouterr()
+        assert out == ""
+        errlines = err.splitlines()
+        assert len(errlines) == 6
+        assert errlines[4].rstrip().endswith(" delta")
+        assert errlines[5].rstrip().endswith("%")
+
+    def test_baseline_missing_function(self, capsys, tmp_path):
+        def sample() -> int:
+            return 42
+
+        path = tmp_path / "tprof.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "label": None,
+                    "functions": [{"name": "other:function", "median_ns": 1.0}],
+                }
+            )
+        )
+
+        with tprof(sample, baseline_path=str(path)):
+            sample()
+
+        out, err = capsys.readouterr()
+        assert out == ""
+        errlines = err.splitlines()
+        assert len(errlines) == 3
+        assert errlines[2].rstrip().endswith(" n/a")
+
+    def test_baseline_invalid(self, tmp_path):
+        def sample() -> int:
+            return 42  # pragma: no cover
+
+        path = tmp_path / "tprof.json"
+        path.write_text("[]")
+
+        with (
+            pytest.raises(ValueError) as excinfo,
+            tprof(sample, baseline_path=str(path)),
+        ):
+            pass  # pragma: no cover
+
+        assert str(excinfo.value).startswith(
+            f"Cannot load baseline from {str(path)!r}:"
+        )
 
     def test_threaded(self, capsys):
         def worker() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from contextlib import chdir
@@ -7,6 +8,7 @@ from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 
+import pytest
 from rich.console import Console
 
 from tprof import __main__  # noqa: F401
@@ -175,3 +177,96 @@ def test_main_compare(tmp_path, capsys):
     assert errlines[2].rstrip().endswith(" -")
     assert errlines[3].startswith(" example:after() ")
     assert errlines[3].rstrip().endswith("%")
+
+
+SLEEPY_SCRIPT = dedent(
+    """\
+    import time
+
+    def snooze():
+        time.sleep(0.001)
+
+    for _ in range(5):
+        snooze()
+    """
+)
+
+
+def test_main_json(tmp_path, capsys):
+    (tmp_path / "example.py").write_text(SLEEPY_SCRIPT)
+    json_path = tmp_path / "tprof.json"
+
+    try:
+        with chdir(tmp_path):
+            result = main(["-t", "snooze", "--json", str(json_path), "-m", "example"])
+    finally:
+        sys.modules.pop("example", None)
+
+    assert result == 0
+    data = json.loads(json_path.read_text())
+    assert data["version"] == 1
+    assert data["label"] is None
+    (function_data,) = data["functions"]
+    assert function_data["name"] == "example:snooze"
+    assert function_data["calls"] == 5
+    assert function_data["median_ns"] >= 1_000_000
+
+
+def test_main_json_stdout(tmp_path, capsys):
+    (tmp_path / "example.py").write_text(SLEEPY_SCRIPT)
+
+    try:
+        with chdir(tmp_path):
+            result = main(["-t", "snooze", "--json", "-", "-m", "example"])
+    finally:
+        sys.modules.pop("example", None)
+
+    assert result == 0
+    out, err = capsys.readouterr()
+    data = json.loads(out)
+    assert data["version"] == 1
+
+
+def test_main_baseline(tmp_path, capsys):
+    (tmp_path / "example.py").write_text(SLEEPY_SCRIPT)
+    json_path = tmp_path / "tprof.json"
+
+    try:
+        with chdir(tmp_path):
+            result = main(["-t", "snooze", "--json", str(json_path), "-m", "example"])
+            assert result == 0
+            result = main(
+                ["-t", "snooze", "--baseline", str(json_path), "-m", "example"]
+            )
+    finally:
+        sys.modules.pop("example", None)
+
+    assert result == 0
+    out, err = capsys.readouterr()
+    errlines = err.splitlines()
+    assert len(errlines) == 6
+    assert errlines[4].rstrip().endswith(" delta")
+    assert errlines[5].startswith(" example:snooze() ")
+    assert errlines[5].rstrip().endswith("%")
+
+
+def test_main_baseline_invalid(tmp_path, capsys):
+    (tmp_path / "example.py").write_text(SLEEPY_SCRIPT)
+    json_path = tmp_path / "tprof.json"
+    json_path.write_text("[]")
+
+    with chdir(tmp_path):
+        result = main(["-t", "snooze", "--baseline", str(json_path), "-m", "example"])
+
+    assert result == 2
+    out, err = capsys.readouterr()
+    assert err.startswith("tprof: Cannot load baseline from ")
+
+
+def test_main_baseline_and_compare(tmp_path, capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        main(["-t", "example:snooze", "-x", "--baseline", "tprof.json", "example.py"])
+
+    assert excinfo.value.code == 2
+    out, err = capsys.readouterr()
+    assert "not allowed with argument" in err


### PR DESCRIPTION
Add two options useful for comparing data between runs, such as when switching Git branches:

* `--json <path>` (`json_path` in the API) writes the statistics to a file
  as JSON, or to stdout with '-'.

* `--baseline <path>` (`baseline_path` in the API) reads a previous run's
  `--json` output and shows a delta column comparing each function's
  median against that run. Mutually exclusive with `-x` (`--compare`), which
  compares between targets within one run.